### PR TITLE
Remove AssignmentPattern.operator when explicitly parsing binding.

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -150,7 +150,6 @@ pp.parseMaybeDefault = function(startPos, startLoc, left) {
   left = left || this.parseBindingAtom()
   if (!this.eat(tt.eq)) return left
   let node = this.startNodeAt(startPos, startLoc)
-  node.operator = "="
   node.left = left
   node.right = this.parseMaybeAssign()
   return this.finishNode(node, "AssignmentPattern")


### PR DESCRIPTION
Closes #301.